### PR TITLE
Add is_done method to deadline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 *.gcno
 *.gcda
 *.profraw
+*.o

--- a/README.md
+++ b/README.md
@@ -150,20 +150,23 @@ create a deadline object.
 
 ```lua
 local sleep = require('time.sleep')
-local deadline = require('time.clock.deadline').new
+local new_deadline = require('time.clock.deadline').new
 
 local deadl, sec = new_deadline(1.5)
 print(deadl) -- time.clock.deadline: 0x600001348088
 print(sec)
+print(deadl:is_done()) -- false
 -- get the remaining time of the deadline
-sec = d:remain()
+sec = deadl:remain()
 print(sec) -- 1.499998
 sleep(1.2)
 sec = deadl:remain()
 print(sec) -- 0.294888
+print(deadl:is_done()) -- false
 sleep(0.3)
 sec = deadl:remain()
 print(sec) -- 0.0
+print(deadl:is_done()) -- true
 ```
 
 
@@ -192,5 +195,13 @@ get the remaining time of the deadline.
 
 **Returns**
 
-- `sec:number`: the remaining time until the deadline　in seconds.
+- `sec:number`: the remaining time until the deadline in seconds.
 
+
+## done = deadline:is_done()
+
+check whether the deadline has expired.
+
+**Returns**
+
+- `done:boolean`: `true` if the deadline has expired, otherwise `false`.

--- a/src/deadline.c
+++ b/src/deadline.c
@@ -28,10 +28,9 @@ typedef struct {
     struct timespec deadline;
 } clock_deadline_t;
 
-static int remain_lua(lua_State *L)
+static inline double get_delta(clock_deadline_t *d)
 {
-    clock_deadline_t *d = luaL_checkudata(L, 1, MODULE_MT);
-    double delta        = 0;
+    double delta = 0;
 
     if (!d->done) {
         struct timespec now = {0};
@@ -46,7 +45,20 @@ static int remain_lua(lua_State *L)
         }
     }
 
-    lua_pushnumber(L, delta);
+    return delta;
+}
+
+static int is_done_lua(lua_State *L)
+{
+    clock_deadline_t *d = luaL_checkudata(L, 1, MODULE_MT);
+    lua_pushboolean(L, !get_delta(d));
+    return 1;
+}
+
+static int remain_lua(lua_State *L)
+{
+    clock_deadline_t *d = luaL_checkudata(L, 1, MODULE_MT);
+    lua_pushnumber(L, get_delta(d));
     return 1;
 }
 
@@ -102,9 +114,10 @@ LUALIB_API int luaopen_time_clock_deadline(lua_State *L)
             {NULL,         NULL        }
         };
         struct luaL_Reg methods[] = {
-            {"time",   time_lua  },
-            {"remain", remain_lua},
-            {NULL,     NULL      }
+            {"time",    time_lua   },
+            {"remain",  remain_lua },
+            {"is_done", is_done_lua},
+            {NULL,      NULL       }
         };
 
         // push metamethods

--- a/test/clock_test.lua
+++ b/test/clock_test.lua
@@ -115,6 +115,9 @@ local function test_deadline()
     -- test that returns a deadline time as number
     assert.equal(deadl:time(), t)
 
+    -- test that return false for is_done() before remaining time is elapsed
+    assert.is_false(deadl:is_done())
+
     -- test that deadline:remain() returns a remain duration of deadline
     local remain = assert(deadl:remain())
     assert.greater(remain, 1.8)
@@ -128,6 +131,9 @@ local function test_deadline()
     sleep(0.2)
     remain = assert(deadl:remain())
     assert.equal(remain, 0)
+
+    -- test that return true for is_done() after remaining time is elapsed
+    assert.is_true(deadl:is_done())
 end
 
 for name, f in pairs({


### PR DESCRIPTION
This pull request introduces a new method to the `deadline` object for checking if the deadline has expired, along with associated documentation and tests. The main focus is on improving usability by allowing users to directly determine if a deadline has passed via an `is_done` method.

**New Feature: Deadline Expiry Check**

* Added a new method `is_done` to the `deadline` object in `src/deadline.c`, which returns `true` if the deadline has expired and `false` otherwise. [[1]](diffhunk://#diff-bbf9136db56a3e45da02260c6d32bf17f4f9bdd3efd372c7043202c0aaa1fb8cL49-R61) [[2]](diffhunk://#diff-bbf9136db56a3e45da02260c6d32bf17f4f9bdd3efd372c7043202c0aaa1fb8cR119)
* Updated the documentation in `README.md` to describe the new `is_done` method, including usage examples and return values. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L153-R169) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L195-R207)
* Added tests in `test/clock_test.lua` to verify the correct behavior of the new `is_done` method before and after the deadline expires. [[1]](diffhunk://#diff-f2849a3ff5b1c0b8c8414f6bc6c3e3c5e2e3eafdfe2bb98dfec2e8396ca26e00R118-R120) [[2]](diffhunk://#diff-f2849a3ff5b1c0b8c8414f6bc6c3e3c5e2e3eafdfe2bb98dfec2e8396ca26e00R134-R136)

**Internal Refactoring**

* Refactored the calculation of the remaining time into a helper function `get_delta` in `src/deadline.c` for reuse in both `remain` and `is_done` methods.