### PR TITLE
Change deadline.is_done method to return remaining time until deadline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         luacheck .
 
   test:
+    needs: luacheck
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mah0x211/lua-ci:latest

--- a/README.md
+++ b/README.md
@@ -198,10 +198,12 @@ get the remaining time of the deadline.
 - `sec:number`: the remaining time until the deadline in seconds.
 
 
-## done = deadline:is_done()
+## done, remain = deadline:is_done()
 
 check whether the deadline has expired.
 
 **Returns**
 
 - `done:boolean`: `true` if the deadline has expired, otherwise `false`.
+- `remain:number`: the remaining time until the deadline in seconds.
+

--- a/src/deadline.c
+++ b/src/deadline.c
@@ -51,8 +51,10 @@ static inline double get_delta(clock_deadline_t *d)
 static int is_done_lua(lua_State *L)
 {
     clock_deadline_t *d = luaL_checkudata(L, 1, MODULE_MT);
-    lua_pushboolean(L, !get_delta(d));
-    return 1;
+    double delta        = get_delta(d);
+    lua_pushboolean(L, !delta);
+    lua_pushnumber(L, delta);
+    return 2;
 }
 
 static int remain_lua(lua_State *L)

--- a/test/clock_test.lua
+++ b/test/clock_test.lua
@@ -116,10 +116,12 @@ local function test_deadline()
     assert.equal(deadl:time(), t)
 
     -- test that return false for is_done() before remaining time is elapsed
-    assert.is_false(deadl:is_done())
+    local done, remain = deadl:is_done()
+    assert.is_false(done)
+    assert.greater(remain, 0)
 
     -- test that deadline:remain() returns a remain duration of deadline
-    local remain = assert(deadl:remain())
+    remain = assert(deadl:remain())
     assert.greater(remain, 1.8)
 
     -- test that deadline:remain() is greater than 0.1 after sleep 1.3 sec
@@ -133,7 +135,9 @@ local function test_deadline()
     assert.equal(remain, 0)
 
     -- test that return true for is_done() after remaining time is elapsed
-    assert.is_true(deadl:is_done())
+    done, remain = deadl:is_done()
+    assert.is_true(done)
+    assert.equal(remain, 0)
 end
 
 for name, f in pairs({


### PR DESCRIPTION
This pull request updates the behavior and documentation of the `deadline:is_done()` function to return both whether the deadline has expired and the remaining time, and adjusts the tests and C implementation accordingly.

**API and Documentation Updates:**

* The `deadline:is_done()` function now returns two values: a boolean indicating if the deadline has expired, and the remaining time in seconds. The documentation in `README.md` has been updated to reflect this change.

**Implementation Changes:**

* The C implementation of `is_done_lua` in `src/deadline.c` has been modified to return both the boolean and the remaining time as a number.

**Test Updates:**

* Tests in `test/clock_test.lua` have been updated to check both the boolean and the remaining time returned by `is_done()`, before and after the deadline expires. [[1]](diffhunk://#diff-f2849a3ff5b1c0b8c8414f6bc6c3e3c5e2e3eafdfe2bb98dfec2e8396ca26e00L119-R121) [[2]](diffhunk://#diff-f2849a3ff5b1c0b8c8414f6bc6c3e3c5e2e3eafdfe2bb98dfec2e8396ca26e00L136-R140)